### PR TITLE
Fix: Log timeouts as failures

### DIFF
--- a/lib/rufus-runner/tracking_scheduler/forking_job_runner.rb
+++ b/lib/rufus-runner/tracking_scheduler/forking_job_runner.rb
@@ -14,6 +14,7 @@ class Rufus::TrackingScheduler::ForkingJobRunner < Rufus::TrackingScheduler::Job
     end
   rescue Rufus::Scheduler::TimeOutError
     kill
+    raise
   end
 
   def shutdown

--- a/spec/tracking_scheduler_spec.rb
+++ b/spec/tracking_scheduler_spec.rb
@@ -167,6 +167,13 @@ describe Rufus::TrackingScheduler do
             wait_for_file(pid_job_3).should be_false
           end
 
+          it 'logs timeouts' do
+            wait_for_file(pid_job_3)
+            pid_job_1.delete
+            wait_for_file(pid_job_1)
+            scheduler_output.should =~ /job_3.*failed.*TimeOutError/
+          end
+
           it 'logs jobs starting and ending' do
             wait_for_file(pid_job_2)
             scheduler_output.should =~ /job_1.*starting/


### PR DESCRIPTION
Timeout errors were not logged as failures when using the :fork strategy.
