### PR TITLE
Fix: Options merged incorrectly

### DIFF
--- a/lib/rufus-runner/tracking_scheduler.rb
+++ b/lib/rufus-runner/tracking_scheduler.rb
@@ -22,7 +22,7 @@ class Rufus::TrackingScheduler
 
   def run(options={}, &block)
     return unless rails_environment_matches?(options.delete(:environments))
-    options = options.merge(@options)
+    options = @options.merge(options)
 
     name = options.delete(:name) || 'noname'
     case options.delete(:fork) || :thread

--- a/spec/tracking_scheduler_spec.rb
+++ b/spec/tracking_scheduler_spec.rb
@@ -307,5 +307,23 @@ describe Rufus::TrackingScheduler do
       subject.scheduler.stub(:every).and_yield(double('job'))
       subject.run(:fork => :thread, :every => 'period')
     end
+
+    it 'allows to set global options' do
+      tracking_scheduler = subject.class.new(:timeout => 50)
+      tracking_scheduler.scheduler.should_receive(:every).with(
+        'period',
+        hash_including(:timeout => 50)
+      )
+      tracking_scheduler.run(:every => 'period')
+    end
+
+    it 'allows to override options' do
+      tracking_scheduler = subject.class.new(:timeout => 50)
+      tracking_scheduler.scheduler.should_receive(:every).with(
+        'period',
+        hash_including(:timeout => 40)
+      )
+      tracking_scheduler.run(:every => 'period', :timeout => 40)
+    end
   end
 end


### PR DESCRIPTION
If you do

``` ruby
Rufus::TrackingScheduler.start :timeout => 60 do |scheduler|
  scheduler.run :timeout => 20 do
    ...
  end
end
```

the `:timeout => 60` wins. This PR fixes that.
