### PR TITLE
Fixes failures when RACK_ENV is set

### DIFF
--- a/spec/tracking_scheduler_spec.rb
+++ b/spec/tracking_scheduler_spec.rb
@@ -138,7 +138,7 @@ describe Rufus::TrackingScheduler do
             run_schedule
             wait_for_file SCHEDULER_PID_FILE or raise
           end
-      
+
           it 'runs jobs' do
             wait_for_file(SCHEDULER_PID_FILE).should be_true
           end
@@ -225,11 +225,11 @@ describe Rufus::TrackingScheduler do
 
         def with_environment(env, &block)
           begin
-            old_env = ENV['RAILS_ENV']
-            ENV['RAILS_ENV'] = env
+            old_env = ENV['RAILS_ENV'] || ENV['RACK_ENV']
+            ENV['RAILS_ENV'] = ENV['RACK_ENV'] = env
             yield
           ensure
-            ENV['RAILS_ENV'] = old_env
+            ENV['RAILS_ENV'] = ENV['RACK_ENV'] = old_env
           end
         end
 


### PR DESCRIPTION
The `with_environment` spec helper only took into account `RAILS_ENV`, this
should fix it by setting/resetting `RACK_ENV` at the same time
